### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Running natively on AARCH64?
+
 # Bloomberg Python API
 
 This directory contains an interface for interacting with Bloomberg API


### PR DESCRIPTION
I am trying to build a Docker image using ARM64, so it runs native on my M1 Mac, but I am unable to install blpapi within this image since Linux ARM64 wheels don’t seem to be provided in the Python package.  To try and get around this I added the BBG C++ SDK in the image and set the BLPAPI_ROOT but I get these errors when trying to install the blpapi package:
 
gcc -pthread -shared -Wl,-rpath=$ORIGIN/../lib,--strip-all build/temp.linux-aarch64-cpython-311/src/blpapi/internals_wrap.o -L/app/blpapi_cpp_3.19.1.1/Linux -L/usr/local/lib -lblpapi3_64 -o build/lib.linux-aarch64-cpython-311/blpapi/_internals.cpython-311-aarch64-linux-gnu.so
/usr/bin/ld: skipping incompatible /app/blpapi_cpp_3.19.1.1/Linux/libblpapi3_64.so when searching for -lblpapi3_64
/usr/bin/ld: cannot find -lblpapi3_64
/usr/bin/ld: skipping incompatible /app/blpapi_cpp_3.19.1.1/Linux/libblpapi3_64.so when searching for -lblpapi3_64
collect2: error: ld returned 1 exit status
 
I think the issue is that the Docker image is ARM64 (aarch64) but the C++ SDK only provides x86/x64.
 
I can install this package directly on my Mac, without using Docker, since it looks like the Python package provides universal wheels for Mac.
 
Not having the ability compile native Docker images is a big negative for our development environment.  It would be great if ARM64/aarch64 wheels were provided by the Python package or if the C++ SDK provided the same.